### PR TITLE
implement Staticman v3 API scheme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,7 @@ repository: 'okfde/edulabs'
 
 staticman:
   branch: "master"
+  git_provider: "github"
 
 title: "edulabs"
 description: "Offene Bildung mit digital gestützten Methoden"

--- a/_includes/add_dwtool.liquid
+++ b/_includes/add_dwtool.liquid
@@ -32,7 +32,7 @@
             <p>Mit diesem Formular kannst du bestehendes Unterrichtsmaterial als Materialkarte zur edulabs-Sammlung hinzufügen. Das Material muss über einen Link erreichbar und <a href="/about/OER">frei lizenziert</a> sein. Ziel der edulabs-Sammlung ist die Empfehlung von besonders gut geeigneten Materialien, die digitale, kommunikative, kreative, kollaborative und kritische Kompetenzen fördern. Nachdem du die Materialkarte eingereicht hast, wird sie durch die <a href="/oer/about">edulabs-Redaktion</a> evaluiert.</p>
         </div>
         <div class="row content-wrap">
-          <form id="edit-project-form" class="form" method="post" action="{{ site.staticman_server }}/v2/entry/{{ site.repository }}/master/dw">
+          <form id="edit-project-form" class="form" method="post" action="{{ site.staticman_server }}/v3/entry/{{ site.staticman.git_provider }}/{{ site.repository }}/master/dw">
 
             <!-- Random Slug -->
             <input type="hidden" id="random-slug" name="fields[title]" value="{{ project_random_slug }}" spellcheck="false" {{editable}}/>

--- a/_includes/add_project.liquid
+++ b/_includes/add_project.liquid
@@ -23,7 +23,7 @@
             <!--    <p>Von der Idee zum Projekt: In den edulabs entwickeln Teams zusammen Projekte für zeitgemäße Bildung. Projektideen sammeln wir zuerst im <a href="https://hackdash.org/dashboards/edulabs">edulabs Hackdash</a>. Hat sich eine Arbeitsgruppe gefunden, wird diese sowie das Vorhaben im Folgenden aufgeführt.</p> -->
         </div>
         <div class="row content-wrap">
-          <form id="edit-project-form" class="form" method="post" action="{{ site.staticman_server }}/v2/entry/{{ site.repository }}/{{ site.staticman.branch }}/projects">
+          <form id="edit-project-form" class="form" method="post" action="{{ site.staticman_server }}/v3/entry/{{ site.staticman.git_provider }}/{{ site.repository }}/{{ site.staticman.branch }}/projects">
 
             <!-- Project Name -->
             <fieldset>

--- a/_includes/page__comments.html
+++ b/_includes/page__comments.html
@@ -33,7 +33,7 @@
     <div id="respond">
       <h3 class="page__section-label">Hinterlasse einen Kommentar <small><a rel="nofollow" id="cancel-comment-reply-link" href="{{ page.url | absolute_url }}#respond" style="display:none;">Cancel reply</a></small></h3>
       <p class="instruct"><a href="https://daringfireball.net/projects/markdown/syntax">Markdown</a> ist erlaubt. Die Email-Adresse wird nicht veröffentlicht.</p>
-      <form id="comment-form" class="page__form js-form form" method="post" action="{{ site.staticman_server }}/v2/entry/{{ site.repository }}/{{ site.staticman.branch }}/comments">
+      <form id="comment-form" class="page__form js-form form" method="post" action="{{ site.staticman_server }}/v3/entry/{{ site.staticman.git_provider }}/{{ site.repository }}/{{ site.staticman.branch }}/comments">
         <fieldset>
           <label for="comment-form-message"><strong>Kommentar</strong> <span class="required">*</span></label>
           <textarea rows="6" id="comment-form-message" name="fields[message]" spellcheck="true"></textarea>


### PR DESCRIPTION
Staticman's docs have recently been updated.  On GitHub, the new GitHub App authorization mechanism is preferred over the traditional GitHub bot as the former is more resistant to GitHub's API rate limit (c.f. Staticman issues 222, 227, 243, 255).

https://github.com/okfde/edulabs/blob/41d5e94517cff6d6b0c62f28ea0689b14b5befa6/assets/js/main.js#L33-L34

From the official guide, the format of Staticman v3's POST URL is

    {STATICMAN_BASE_URL}/v3/entry/{GIT_PROVIDER}/{GIT_PROVIDER_USERNAME}/{REPO}/{BRANCH}/{property (optional)}

e.g.

    https://staticmaninstance.herokuapp.com/v3/entry/github/eduardoboucas/staticman/gh-pages/comments

:link: https://staticman.net/docs/getting-started.html